### PR TITLE
Use Bool, not Long, to determine if session key exists

### DIFF
--- a/src/main/java/com/ovea/jetty/session/redis/RedisSessionIdManager.java
+++ b/src/main/java/com/ovea/jetty/session/redis/RedisSessionIdManager.java
@@ -113,11 +113,14 @@ public final class RedisSessionIdManager extends SessionIdManagerSkeleton {
                 });
             }
         });
-        for (int i = 0; i < status.size(); i++)
-            if (ZERO.equals(status.get(i)))
+        for (int i = 0; i < status.size(); i++) {
+            if (status.get(i).equals(false)) {
                 expired.add(clusterIds.get(i));
-        if (LOG.isDebugEnabled() && !expired.isEmpty())
+            }
+        }
+        if (LOG.isDebugEnabled()) {
             LOG.debug("[RedisSessionIdManager] Scavenger found {} sessions to expire: {}", expired.size(), expired);
+        }
         return expired;
     }
 


### PR DESCRIPTION
This class calls jedis.exists() to determine if a session key has
expired or not - but was comparing the return value vs. 0L
instead of vs. a boolean false, so RedisSessions would never be
scavenged, leaking resources.

See:
https://github.com/Ovea/jetty-session-redis/issues/7
