### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,14 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.0.0</version>
+            <version>2.8.1</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all</artifactId>
-            <version>8.1.2.v20120308</version>
+            <version>9.3.10.v20160621</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Binary compatibility is broken in Jedis 2.0.0. Updating jedis maven version to latest as using 2.0.0 with an application which uses latest Jedis 2.8.1 breaks. Reference : https://github.com/xetorthio/jedis/issues/303

Kindly approve if this is ok. Will enable me to use this library. Thanks
